### PR TITLE
Check for null timestamps

### DIFF
--- a/yiffscraper/downloader.py
+++ b/yiffscraper/downloader.py
@@ -67,7 +67,8 @@ class UrlItem:
                     out_file.write(chunk)
 
         url_timestamp = getTimestamp(self.lastModified)
-        os.utime(self.path, (url_timestamp, url_timestamp))
+        if url_timestamp is not None:
+            os.utime(self.path, (url_timestamp, url_timestamp))
         return (self, None)
 
     @classmethod


### PR DESCRIPTION
If the server doesn't provide the header, `os.utime` shouldn't be called